### PR TITLE
Change permissions for Root CA Cert

### DIFF
--- a/provision-aws-iot-thing.sh
+++ b/provision-aws-iot-thing.sh
@@ -98,3 +98,4 @@ fi
 
 chmod 700 $CERTS_DIR
 chmod 644 $DEVICE_CERT_PATH
+chmod 644 $ROOT_CERT_PATH


### PR DESCRIPTION
The Device Client requires that the Root CA Cert permissions are set
to 644 in order to accept the cert. This commit modifies the permissions
for the file once it is downloaded so that the Device Client will accept
it.